### PR TITLE
Add wally-cli command to zsa-wally cask

### DIFF
--- a/Casks/zsa-wally.rb
+++ b/Casks/zsa-wally.rb
@@ -9,4 +9,5 @@ cask 'zsa-wally' do
   homepage 'https://ergodox-ez.com/pages/wally'
 
   app 'Wally.app'
+  binary 'wally-cli'
 end


### PR DESCRIPTION
The dmg package also provides the command line utility although this is not within the app but as a separate file. Uses `binary` stanza as suggested by https://github.com/Homebrew/homebrew-cask-drivers/issues/1398)

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).